### PR TITLE
chore: install package deps for offline build

### DIFF
--- a/README_OFFLINE.md
+++ b/README_OFFLINE.md
@@ -10,7 +10,7 @@ This fork removes all network calls to `continue.dev` and PostHog so the VS Code
 npm run build-offline
 ```
 
-This installs dependencies, builds the React GUI, and packages the VS Code extension into `extensions/vscode/build/continue-<version>.vsix`.
+This command first runs `npm run prebuild-offline` to install dependencies for each package and the GUI, then builds the React GUI and packages the VS Code extension into `extensions/vscode/build/continue-<version>.vsix`. Run this step while online so all dependencies can be downloaded; after that, it can be re-run offline.
 
 ## Installing
 

--- a/gui/src/stubs/posthog-js.ts
+++ b/gui/src/stubs/posthog-js.ts
@@ -1,9 +1,9 @@
 const posthog = {
-  init: () => {},
-  capture: () => {},
-  identify: () => {},
-  opt_in_capturing: () => {},
-  opt_out_capturing: () => {},
+  init: (..._args: any[]) => {},
+  capture: (..._args: any[]) => {},
+  identify: (..._args: any[]) => {},
+  opt_in_capturing: (..._args: any[]) => {},
+  opt_out_capturing: (..._args: any[]) => {},
 };
 
 export default posthog;

--- a/gui/tsconfig.json
+++ b/gui/tsconfig.json
@@ -16,7 +16,11 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "noEmitOnError": false,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "paths": {
+      "posthog-js": ["./src/stubs/posthog-js"],
+      "posthog-js/react": ["./src/stubs/posthog-react"]
+    }
     // Disabled for now since it's causing too many errors
   },
   "include": ["src", "../src/util/messenger.ts"],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "tsc:watch:binary": "tsc --project binary/tsconfig.json --watch --noEmit --pretty",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\" --ignore-path .gitignore",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\" --ignore-path .gitignore",
-    "build-offline": "npm install && npm --prefix extensions/vscode run build-offline"
+    "prebuild-offline": "npm install && npm install --prefix packages/config-types && npm install --prefix packages/config-yaml && npm install --prefix packages/fetch && npm install --prefix packages/openai-adapters && npm install --prefix packages/llm-info && npm install --prefix gui",
+    "build-offline": "npm run prebuild-offline && npm --prefix extensions/vscode run build-offline"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^7.8.0",


### PR DESCRIPTION
## Summary
- ensure build script installs all package dependencies before building VS Code extension
- document the updated offline build step
- stub PostHog modules with path aliases so the GUI compiles offline

## Testing
- `npm run build-offline`

------
https://chatgpt.com/codex/tasks/task_e_689211821fb883279342ea4be0bc3501