### PR TITLE
fix offline build dependencies

### DIFF
--- a/README_OFFLINE.md
+++ b/README_OFFLINE.md
@@ -4,13 +4,28 @@ This fork removes all network calls to `continue.dev` and PostHog so the VS Code
 
 ## Building
 
-1. From the repository root run:
+Before running the build, you need to install dependencies for `core` and the packages under `packages/` and `gui`:
+
+```bash
+cd core && npm install
+cd ../packages/config-types && npm install
+cd ../config-yaml && npm install
+cd ../fetch && npm install
+cd ../openai-adapters && npm install
+cd ../llm-info && npm install
+cd ../../gui && npm install
+cd ..  # return to repository root
+```
+
+Once the dependencies are installed, run:
 
 ```bash
 npm run build-offline
 ```
 
-This command first runs `npm run prebuild-offline` to install dependencies for each package and the GUI, then builds the React GUI and packages the VS Code extension into `extensions/vscode/build/continue-<version>.vsix`. Run this step while online so all dependencies can be downloaded; after that, it can be re-run offline.
+This command installs root dependencies, builds the React GUI, and packages the VS Code extension into `extensions/vscode/build/continue-<version>.vsix`.
+
+Using `npm install --prefix` on Windows is unsafe and should be avoided due to an npm bug.
 
 ## Installing
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "tsc:watch:binary": "tsc --project binary/tsconfig.json --watch --noEmit --pretty",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md}\" --ignore-path .gitignore",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,css,md}\" --ignore-path .gitignore",
-    "prebuild-offline": "npm install && npm install --prefix packages/config-types && npm install --prefix packages/config-yaml && npm install --prefix packages/fetch && npm install --prefix packages/openai-adapters && npm install --prefix packages/llm-info && npm install --prefix gui",
-    "build-offline": "npm run prebuild-offline && npm --prefix extensions/vscode run build-offline"
+    "prebuild-offline": "cd core && npm install && cd .. && cd packages/config-types && npm install && cd ../config-yaml && npm install && cd ../fetch && npm install && cd ../openai-adapters && npm install && cd ../llm-info && npm install && cd ../../gui && npm install && cd ..",
+    "build-offline": "npm install && npm run prebuild-offline && cd extensions/vscode && npm install && npm run build-offline && cd .."
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^7.8.0",


### PR DESCRIPTION
## Summary
- ensure build-offline installs dependencies in each package directory
- document manual dependency installation and warn against `npm install --prefix` on Windows

## Testing
- `npm run build-offline`

------
https://chatgpt.com/codex/tasks/task_e_68921a00535c8327a80f90d0983a70d1