### PR TITLE
Enable local Claude 4 Sonnet configuration for offline use

### DIFF
--- a/.continue/assistants/Local Claude 4.yaml
+++ b/.continue/assistants/Local Claude 4.yaml
@@ -3,7 +3,7 @@ version: 1.0.0
 schema: v1
 
 models:
-  - uses: local/claude-4-sonnet
+  - uses: gvllm/claude-4-sonnet  # owner/block slug avoids hub fetch
 
 context:
   - provider: code

--- a/.continue/config.yaml
+++ b/.continue/config.yaml
@@ -1,0 +1,8 @@
+# Overrides default config so the extension uses only the local assistant.
+name: my-local-setup
+version: 1.0.0
+schema: v1
+
+assistants:
+  - uses: './assistants/Local Claude 4.yaml'
+

--- a/.continue/models/anthropic-claude-4-sonnet.yaml
+++ b/.continue/models/anthropic-claude-4-sonnet.yaml
@@ -1,4 +1,7 @@
-name: local/claude-4-sonnet
+# Use owner-slug/block-slug format per Continue docs to mark this as a local block
+# and declare capabilities required for agent mode and image uploads.
+# https://docs.continue.dev (model configuration)
+name: gvllm/claude-4-sonnet
 version: 0.0.1
 schema: v1
 
@@ -7,6 +10,9 @@ models:
     provider: anthropic
     model: claude-sonnet-4-20250514
     apiKey: ${{ secrets.ANTHROPIC_API_KEY }}
+    capabilities:
+      - tool_use      # required for agent mode
+      - image_input   # optional, enables image uploads
     roles: [chat, edit, apply, autocomplete]
     defaultCompletionOptions:
       temperature: 0.7


### PR DESCRIPTION
## Summary
- Added local Claude 4 Sonnet model block with owner/block slug and required capabilities.
- Updated Local Claude 4 assistant to use the local model.
- Added workspace config to force extension to use this assistant.

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68931b3b1b688327989c9a72cc05c52a